### PR TITLE
fix: only get models that are for db tables

### DIFF
--- a/packages/nocodb/src/lib/elitesoftwareautomation/db/PSQLRecordOperationWatcher.ts
+++ b/packages/nocodb/src/lib/elitesoftwareautomation/db/PSQLRecordOperationWatcher.ts
@@ -370,7 +370,12 @@ export class PSQLRecordOperationWatcher extends EventEmitter {
     const foundModelData: Record<string, any>[] = await this.ncMeta.metaList2(
       base.project_id,
       base.id,
-      MetaTable.MODELS
+      MetaTable.MODELS,
+      {
+        condition: {
+          type: 'table',
+        },
+      }
     );
 
     const models = foundModelData.map(
@@ -443,7 +448,7 @@ export class PSQLRecordOperationWatcher extends EventEmitter {
     this.log(
       `watching base : ${base.id} , ${
         (await base.getConnectionConfig()).database
-      } )`
+      }`
     );
     this.log(
       `watched models`,


### PR DESCRIPTION
## Change Summary
only get models that are for db tables in PSQLRecordOperationWatcher

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
